### PR TITLE
Vox confirm

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,21 +14,21 @@ gulp.task('compile:build', function() {
     .pipe(gulp.dest('./lib'));
 });
 
-gulp.task('copyfont', function() {
+gulp.task('copyfont:build', function() {
   return gulp.src('./src/fonts/**')
     .pipe(cssmin())
     .pipe(gulp.dest('./lib/fonts'));
 });
 
-gulp.task('copydevfont', function() {
+gulp.task('copyfont:dev', function() {
   return gulp.src('./src/fonts/**')
     .pipe(cssmin())
     .pipe(gulp.dest('./dev/fonts'));
 });
 
-gulp.task('build', ['compile:build', 'copyfont']);
+gulp.task('build', ['compile:build', 'copyfont:build']);
 
-gulp.task('compile:dev', ['copydevfont'], function () {
+gulp.task('compile:dev', function () {
   return gulp.src('./src/*.css')
     .pipe(sourcemaps.init())
     .pipe(postcss([salad]))
@@ -40,7 +40,7 @@ gulp.task('compile:bs', ['compile:dev'], function () {
   browserSync.reload();
 });
 
-gulp.task('dev', function() {
+gulp.task('dev', ['copyfont:dev'], function() {
   browserSync.init({
     server: './',
     port: 9849,

--- a/index.html
+++ b/index.html
@@ -10,6 +10,8 @@
   <link rel="stylesheet" href="./dev/icon.css">
   <link rel="stylesheet" href="./dev/button.css">
   <link rel="stylesheet" href="./dev/pagination.css">
+  <link rel="stylesheet" href="./dev/message.css">
+  <link rel="stylesheet" href="./dev/message-box.css">
   <style>
     /* 测试分页居中 */
     .pagination-center {
@@ -35,6 +37,7 @@
     <li><a href="#pagination">pagination</a></li>
     <li><a href="#form">form/input</a></li>
     <li><a href="#popover">popover</a></li>
+    <li><a href="#message-box">message-box</a></li>
   </ul>
   <div id="app">
     <div id="radio">
@@ -124,9 +127,15 @@
         <el-button v-popover:popover3>Click Right-Start Custom Content</el-button>
       </div>
     </div>
+    <div id="message-box">
+      <h2>message-box</h2>
+      <div>
+        <el-button type="text" @click="open2">点击打开 Message Box</el-button>
+      </div>
+    </div>
   </div>
-  <script src="https://unpkg.com/vue/dist/vue.js"></script>
-  <script src="https://unpkg.com/element-ui/lib/index.js"></script>
+  <script src="//cdn.bootcss.com/vue/2.3.4/vue.js"></script>
+  <script src="//cdn.bootcss.com/element-ui/1.3.6/index.js"></script>
   <script>
     new Vue({
       el: '#app',
@@ -152,6 +161,19 @@
       methods: {
         hidePopover(event) {
           document.documentElement.click();
+        },
+        open2() {
+          this.$confirm(''/* content */, '确定要删除该商品吗？' /* title */, {
+            confirmButtonText: '确定',
+            confirmButtonClass: 'vox-button__confirm',
+            cancelButtonText: '取消',
+            cancelButtonClass: 'vox-button__cancel'
+          }).then(() => {
+            this.$message({
+              type: 'success',
+              message: '删除成功!'
+            });
+          });
         }
       },
     })

--- a/index.html
+++ b/index.html
@@ -165,9 +165,9 @@
         open2() {
           this.$confirm(''/* content */, '确定要删除该商品吗？' /* title */, {
             confirmButtonText: '确定',
-            confirmButtonClass: 'vox-button__confirm',
+            confirmButtonClass: 'vox-Button__confirm',
             cancelButtonText: '取消',
-            cancelButtonClass: 'vox-button__cancel'
+            cancelButtonClass: 'vox-Button__cancel'
           }).then(() => {
             this.$message({
               type: 'success',

--- a/src/button.css
+++ b/src/button.css
@@ -21,7 +21,7 @@
     & + .el-button {
       margin-left: 10px;
     }
-    
+
     @mixin button-size var(--button-padding-vertical), var(--button-padding-horizontal), var(--button-font-size), var(--button-border-radius);
 
     &:hover,
@@ -29,7 +29,7 @@
       color: var(--color-primary);
       border-color: @color;
     }
-    
+
     &:active {
       color: shade(var(--color-primary), var(--button-active-shade-percent));
       border-color: @color;
@@ -53,7 +53,7 @@
         border-color: var(--color-primary);
         color: var(--color-primary);
       }
-      
+
       &:active {
         background: var(--color-white);
         border-color: shade(var(--color-primary), var(--button-active-shade-percent));
@@ -203,4 +203,14 @@
       }
     }
   }
+}
+
+.vox-button__confirm {
+  @mixin vox-button #FFF, #D63C15, #C23714;
+  margin-left: 0;
+}
+
+.vox-button__cancel {
+  @mixin vox-button #888, #F4F4F4, #EAEAEA;
+  margin-left: 20px;
 }

--- a/src/button.css
+++ b/src/button.css
@@ -205,12 +205,12 @@
   }
 }
 
-.vox-button__confirm {
+.vox-Button__confirm {
   @mixin vox-button #FFF, #D63C15, #C23714;
   margin-left: 0;
 }
 
-.vox-button__cancel {
+.vox-Button__cancel {
   @mixin vox-button #888, #F4F4F4, #EAEAEA;
   margin-left: 20px;
 }

--- a/src/message-box.css
+++ b/src/message-box.css
@@ -11,8 +11,8 @@
     display: inline-block;
     vertical-align: middle;
     background-color: var(--color-white);
-    width: var(--msgbox-width);
-    border-radius: var(--msgbox-border-radius);
+    width: 300px;
+    border-radius: 4px;
     font-size: var(--msgbox-font-size);
     overflow: hidden;
     backface-visibility: hidden;
@@ -39,8 +39,8 @@
 
     @e headerbtn {
       position: absolute;
-      top: 19px;
-      right: 20px;
+      top: 15px;
+      right: 15px;
       background: transparent;
       border: none;
       outline: none;
@@ -50,10 +50,10 @@
       .el-message-box__close {
         color: #999;
       }
-      
+
       &:focus, &:hover {
         .el-message-box__close {
-          color: var(--color-primary);
+          color: var(--color-skin-hover);
         }
       }
 
@@ -86,10 +86,10 @@
     @e title {
       padding-left: 0;
       margin-bottom: 0;
-      font-size: var(--msgbox-font-size);
-      font-weight: bold;
+      font-size: 14;
+      font-weight: 700;
       height: 18px;
-      color: #333;
+      color: #222;
     }
 
     @e message {
@@ -102,11 +102,13 @@
     }
 
     @e btns {
-      padding: 10px 20px 15px;
-      text-align: right;
+      padding: 24px 20px 20px 20px;
+      display: flex;
+      flex-flow: row-reverse;
+      justify-content: flex-end;
 
       & button:nth-child(2) {
-        margin-left: 10px;
+        margin-left: 0;
       }
     }
 
@@ -167,4 +169,8 @@
     transform: translate3d(0, -20px, 0);
     opacity: 0;
   }
+}
+
+.v-modal {
+  opacity: 0.1;
 }

--- a/src/mixins/_button.css
+++ b/src/mixins/_button.css
@@ -9,7 +9,7 @@
     border-color: tint($border-color, var(--button-hover-tint-percent));
     color: $color;
   }
-  
+
   &:active {
     background: shade($background-color, var(--button-active-shade-percent));
     border-color: shade($border-color, var(--button-active-shade-percent));
@@ -34,7 +34,7 @@
       border-color: $border-color;
       color: $background-color;
     }
-    
+
     &:active {
       background: var(--color-white);
       border-color: shade($border-color, var(--button-active-shade-percent));
@@ -48,4 +48,25 @@
   padding: $padding-vertical $padding-horizontal;
   font-size: $font-size;
   border-radius: $border-radius;
+}
+
+@define-mixin vox-button $text-color, $bg-color, $bg-color-hover {
+  display: inline-block;
+  border-radius: 4px;
+  text-decoration: none;
+  text-align: center;
+  font-weight: 700;
+  font-size: 13px;
+  color: $text-color;
+  line-height: 36px;
+  height: 36px;
+  cursor: pointer;
+  padding: 0 16px;
+  background-color: $bg-color;
+  border: 0;
+  &:hover,
+  &:focus {
+    color: $text-color;
+    background-color: $bg-color-hover;
+  }
 }


### PR DESCRIPTION
## theme-default

这个对样式的修改，都放在了 theme-default 这边。没有放在 radiohead 处理的原因是，我们要用到 `message-box` 自身带的 `按钮功能` 。

- 对于 `确定`、`取消` 按钮样式的修改，通过自定义类名 `vox-Button__confirm` 和 `vox-Button__cancel` 来覆盖。样式来自 radiohead 中的 `Button`。
- `message-box` 相关样式的修改。
- 遮罩层 `v-model` 透明度修改。

## 其他

- 换了 CDN 源，加载速度快上几秒
- 修改了 gulp 脚本，`copyfont:dev` 只在 dev 任务运行时执行一次。